### PR TITLE
Use "clear compiler"

### DIFF
--- a/.idea/.idea.PascalABC.NET.SDK/.idea/dictionaries/fried.xml
+++ b/.idea/.idea.PascalABC.NET.SDK/.idea/dictionaries/fried.xml
@@ -4,6 +4,7 @@
       <w>nupkg</w>
       <w>optout</w>
       <w>pabcnetc</w>
+      <w>pabcnetcclear</w>
     </words>
   </dictionary>
 </component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- The `pabcnetcclear.exe` binary is now used for compilation, since it's more suited for command-line invocation.
+
+### Added
+- New `DebugMode` property is supported and set by default for the `Debug` configuration. Before that, the debug mode was always enabled.
+
 ## [1.0.0] - 2022-09-17
 This is the initial release of the SDK. It allows invoking the compiler to build simple PascalABC.NET programs.
 

--- a/PascalABC.NET.SDK.Demo/FullRebuild.ps1
+++ b/PascalABC.NET.SDK.Demo/FullRebuild.ps1
@@ -1,0 +1,19 @@
+# This script will fully rebuild the SDK and the demo project.
+param (
+    $ProjectDirectory = $PSScriptRoot,
+    $SolutionDirectory = "$ProjectDirectory/.."
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if ((Test-Path $ProjectDirectory/bin) -or (Test-Path $ProjectDirectory/obj)) {
+    Remove-Item -Recurse $ProjectDirectory/bin, $ProjectDirectory/obj
+}
+
+if (Test-Path $SolutionDirectory/packages) {
+    Remove-Item -Recurse $SolutionDirectory/packages
+}
+
+../scripts/build-packages.ps1
+dotnet build -bl $ProjectDirectory/PascalABC.NET.SDK.Demo.pasproj

--- a/PascalABC.NET.SDK.Demo/PascalABC.NET.SDK.Demo.pasproj
+++ b/PascalABC.NET.SDK.Demo/PascalABC.NET.SDK.Demo.pasproj
@@ -9,4 +9,8 @@
         <MainCompile Include="Hello2.pas" />
     </ItemGroup>
 
+    <ItemGroup>
+      <None Include="FullRebuild.ps1" />
+    </ItemGroup>
+
 </Project>

--- a/PascalABC.NET.SDK.TestFramework/SdkTestBase.cs
+++ b/PascalABC.NET.SDK.TestFramework/SdkTestBase.cs
@@ -72,22 +72,12 @@ public abstract class SdkTestBase
 ");
     }
 
-    protected string GetTestDataPath(string relativePath) => Path.Combine(_temporaryPath, relativePath);
+    private string GetTestDataPath(string relativePath) => Path.Combine(_temporaryPath, relativePath);
 
     private async Task<CommandResult> BuildProject(string projectFilePath)
     {
         var command = Command.Run("dotnet",  "build", "--verbosity:normal", projectFilePath);
         return await command.Task;
-    }
-
-    protected async Task TestFailure(string projectFileRelativePath, string errorMessage)
-    {
-        var projectFilePath = GetTestDataPath(projectFileRelativePath);
-        if (!File.Exists(projectFilePath)) throw new Exception($"File \"{projectFilePath}\" doesn't exists.");
-        var result = await BuildProject(projectFilePath);
-        Assert.False(result.Success, "Build should be failed. Stdout: " + result.StandardOutput);
-
-        Assert.Contains(errorMessage, result.StandardOutput);
     }
 
     protected async Task TestSuccess(string projectFileRelativePath, params string[] outputFileRelativePaths)

--- a/PascalABC.NET.SDK.Tests/SimpleCompilationTests.cs
+++ b/PascalABC.NET.SDK.Tests/SimpleCompilationTests.cs
@@ -7,13 +7,4 @@ public class SimpleCompilationTests : SdkTestBase
 {
     [Fact] public Task Test1() => TestSuccess("Test1.pasproj", "bin/Hello1.exe");
     [Fact] public Task Test2() => TestSuccess("Test2.pasproj", "bin/Hello1.exe", "bin/Hello2.exe");
-    [Fact] public async Task BlockedOutputItemTest()
-    {
-        var path = GetTestDataPath("Hello1.exe");
-
-        await File.WriteAllBytesAsync(path, Array.Empty<byte>());
-        await TestFailure(
-            "Test1.pasproj",
-            "already exist on disk but would be removed after compilation. Please clean up manually.");
-    }
 }

--- a/PascalABC.NET.SDK/Sdk/Sdk.props
+++ b/PascalABC.NET.SDK/Sdk/Sdk.props
@@ -1,5 +1,9 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+    <PropertyGroup Label="SdkCustomization">
+        <EnableDefaultItems>false</EnableDefaultItems>
+    </PropertyGroup>
+
     <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
     <PropertyGroup Label="CompilerVersioning">

--- a/PascalABC.NET.SDK/Sdk/Sdk.targets
+++ b/PascalABC.NET.SDK/Sdk/Sdk.targets
@@ -14,7 +14,7 @@
 
         <PascalAbcCompilerCommand Condition=" $(PascalAbcCompilerCommand) == '' ">$(_PascalAbcCompilerAssembly)</PascalAbcCompilerCommand>
 
-        <_PascalAbcCompilerArguments Condition=" $(DebugMode) == 'true' ">$(PascalAbcCompilerArguments) /Debug:1</_PascalAbcCompilerArguments>
+        <_PascalAbcCompilerArguments Condition=" $(DebugMode) == 'true' ">$(_PascalAbcCompilerArguments) /Debug:1</_PascalAbcCompilerArguments>
     </PropertyGroup>
 
     <ItemGroup>

--- a/PascalABC.NET.SDK/Sdk/Sdk.targets
+++ b/PascalABC.NET.SDK/Sdk/Sdk.targets
@@ -2,52 +2,32 @@
 
     <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition=" '$(CommonTargetsPath)' == '' " />
 
+    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+        <DebugMode Condition=" '$(DebugMode)' == '' ">true</DebugMode>
+    </PropertyGroup>
+
     <PropertyGroup>
         <_PascalABCNETCompilerPackagePath>$(NuGetPackageRoot)\$(PascalABCNETCompilerPackageName)\$(PascalABCNETCompilerPackageVersion)</_PascalABCNETCompilerPackagePath>
 
-        <_PascalAbcCompilerAssembly Condition=" $(_PascalAbcCompilerAssembly) == '' and $(SkipPascalABCNETCompilerInstallation) != true ">$(_PascalABCNETCompilerPackagePath)\tools\pabcnetc.exe</_PascalAbcCompilerAssembly>
-        <_PascalAbcCompilerAssembly Condition=" $(_PascalAbcCompilerAssembly) == '' ">pabcnetc.exe</_PascalAbcCompilerAssembly>
+        <_PascalAbcCompilerAssembly Condition=" $(_PascalAbcCompilerAssembly) == '' and $(SkipPascalABCNETCompilerInstallation) != true ">$(_PascalABCNETCompilerPackagePath)\tools\pabcnetcclear.exe</_PascalAbcCompilerAssembly>
+        <_PascalAbcCompilerAssembly Condition=" $(_PascalAbcCompilerAssembly) == '' ">pabcnetcclear.exe</_PascalAbcCompilerAssembly>
 
         <PascalAbcCompilerCommand Condition=" $(PascalAbcCompilerCommand) == '' ">$(_PascalAbcCompilerAssembly)</PascalAbcCompilerCommand>
+
+        <_PascalAbcCompilerArguments Condition=" $(DebugMode) == 'true' ">$(PascalAbcCompilerArguments) /Debug:1</_PascalAbcCompilerArguments>
     </PropertyGroup>
 
-    <!--
-        Due to a bug in pabcnetc (https://github.com/pascalabcnet/pascalabcnet/issues/2708), it always writes the output
-         assembly to the input file directory when called in a way we're calling it.
-
-        Because of this, we have to implement a hack: move the assembly file to the output directory after the
-        compilation (Compile target).
-
-        And if there's already something in the current compilation directory at the moment of compilation, it would be
-        overwritten. To avoid this unexpected overwrite, we check that such item doesn't exist (OutputItemCheck target).
-    -->
-
-    <Target Name="OutputItemCheck" BeforeTargets="Compile" DependsOnTargets="Restore">
-        <ItemGroup>
-            <_CompileOutput Include="@(MainCompile -> '%(RootDir)%(Directory)%(FileName).exe')" />
-            <_CompileOutput Include="@(MainCompile -> '%(RootDir)%(Directory)%(FileName).pdb')" />
-
-            <_ExistingCompileOutput Include="@(_CompileOutput)" Condition=" Exists(%(FullPath)) " />
-        </ItemGroup>
-
-        <Error Condition=" @(_ExistingCompileOutput->Count()) > 0 "
-               Text="Items &quot;%(_ExistingCompileOutput.FullPath)&quot; already exist on disk but would be removed after compilation. Please clean up manually." />
-    </Target>
+    <ItemGroup>
+        <_PascalAbcCompilerOutput Include="@(MainCompile -> '$(OutDir)\%(FileName).exe')" />
+        <_PascalAbcCompilerOutput Include="@(MainCompile -> '$(OutDir)\%(FileName).pdb')" Condition=" $(DebugMode) == 'true' " />
+    </ItemGroup>
 
     <Target Name="Compile" BeforeTargets="Build"
-            Inputs="%(Compile.FullPath);@(MainCompile -> '%(FullPath)')"
-            Outputs="
-                @(MainCompile -> '$(OutDir)\%(FileName).exe');
-                @(MainCompile -> '$(OutDir)\%(FileName).pdb')">
-
-        <ItemGroup>
-            <_CurrentCompileOutput Include="@(MainCompile -> '%(RootDir)%(Directory)%(FileName).exe')" />
-            <_CurrentCompileOutput Include="@(MainCompile -> '%(RootDir)%(Directory)%(FileName).pdb')" />
-        </ItemGroup>
-
-        <Exec Command="$(PascalAbcCompilerCommand) /noconsole %(MainCompile.FullPath)" />
-
-        <Move SourceFiles="%(_CurrentCompileOutput.FullPath)" DestinationFolder="$(OutDir)" />
+            Inputs="@(Compile);@(MainCompile)"
+            Outputs="@(_PascalAbcCompilerOutput)">
+        <MakeDir Directories="$(OutDir)" />
+        <Exec Command="@(MainCompile -> '$(PascalAbcCompilerCommand) $(_PascalAbcCompilerArguments) &quot;/Output:$(OutDir)\%(FileName).exe&quot; %(FullPath)')"
+              Condition=" '%(Identity)' != ''" />
     </Target>
 
     <Target Name="Build" />

--- a/README.md
+++ b/README.md
@@ -51,12 +51,15 @@ Other (non-main) `.pas` files may be added as `<Compile>` items, which are only 
 
 You can change the following properties in your project file to customize the SDK behavior.
 
+<!-- Sdk.props -->
 - `OutDir`: the directory for output assemblies, `$(MSBuildProjectDirectory)\bin\` by default
-- `PascalABCNETCompilerPackageName`: the name of the compiler package that will be downloaded from NuGet, `FVNever.PascalABC.NET.Compiler` by default
-- `PascalABCNETCompilerPackageVersion`: the version of the compiler package to use; may be updated if a new version of the SDK is published
-- `SkipPascalABCNETCompilerInstallation`: set to `true` to skip the compiler installation by the SDK (if you want to get the compiler yourself via other means)
+- `PascalABCNETCompilerPackageName`: the name of the compiler package that will be downloaded from NuGet, `FVNever.PascalABC.NET.Compiler` by default.
+- `PascalABCNETCompilerPackageVersion`: the version of the compiler package to use; may be updated if a new version of the SDK is published.
+- `SkipPascalABCNETCompilerInstallation`: set to `true` to skip the compiler installation by the SDK (if you want to get the compiler yourself via other means).
 
-- `PascalAbcCompilerCommand`: command to run the compiler; just the path to the packaged compiler executable by default
+<!-- Sdk.targets -->
+- `DebugMode`: if `true`, then the compiler will generate debug information and disable the optimizations. Enabled by default for the `Debug` configuration.
+- `PascalAbcCompilerCommand`: command to run the compiler; just the path to the packaged compiler executable by default.
 
 Development
 -----------


### PR DESCRIPTION
I found a `pabcnetcclear.exe` binary (whatever that name means) which is more suited for command-line usage (no random pauses, no `Console.Width` invocation or whatever), that also has certain interesting properties.